### PR TITLE
RDO-1967: Allow user to specify a specific java version to be installed

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,8 @@
 ---
 java:
   version: 1.8.0
+
+# A specific version of Java can also be specified:
+#java:
+#  version: 1.8.0
+#  minver: 1.8.0.171-7.b10.el7

--- a/molecule.yml
+++ b/molecule.yml
@@ -18,3 +18,6 @@ docker:
 
 verifier:
   name: testinfra
+
+ansible:
+  playbook: tests/playbook.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,27 @@
 ---
-- name: install java
-  become: yes
-  yum: pkg=java-{{ java.version }}-openjdk state=installed
+- name: Define java package names
+  set_fact:
+    javapkg_main: "java-{{ java.version }}-openjdk"
+    javapkg_devel: "java-{{ java.version }}-openjdk-devel"
 
-- name: install java devel tools
+- name: Force specific version of java packages when requested
+  set_fact:
+     javapkg_main: "java-{{ java.version }}-openjdk-{{ java.minver }}"
+     javapkg_devel: "java-{{ java.version }}-openjdk-devel-{{ java.minver }}"
+  when: "java.minver is defined"
+
+- name: Show Java version which has been requested
+  debug:
+    msg: "java={{ java }}"
+
+- name: Show name of the Java packages that are going to be installed
+  debug:
+    msg: "javapkg_main={{ javapkg_main }} + javapkg_devel={{ javapkg_devel}}"
+
+- name: install java main package
   become: yes
-  yum: pkg=java-{{ java.version }}-openjdk-devel state=installed
+  yum: pkg={{ javapkg_main }} state=installed
+
+- name: install java devel package
+  become: yes
+  yum: pkg={{ javapkg_devel }} state=installed

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  roles:
+    - role: java-role
+  vars:
+    java:
+      version: 1.8.0


### PR DESCRIPTION
Previously we could select major versions of Java such as 1.7.0 or 1.8.0
This change allows to select a specific version such as "1.8.0.171-7.b10.el7"